### PR TITLE
fix: enforce resolver registry for htlc orders

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -303,7 +303,9 @@ and verified by the resolver before it locks destination-side funds.
   timelock, asset, amount, safety_deposit)` — locks the asset under
   the standard HTLC commitments. Stores the entire order in a
   Soroban `Map<u64, Order>` keyed by an autoincrementing
-  `next_order_id`. Emits the `OrderCreated` event.
+  `next_order_id`. When a registry is configured,
+  `ResolverRegistry.is_active(sender)` must return true. Emits the
+  `OrderCreated` event.
 - `claim_order(env, order_id, preimage)` — `sha256(preimage) ==
   hashlock` and `env.ledger().timestamp() <= timelock` are required.
   Asset transferred to `beneficiary`, safety deposit to `caller`.

--- a/docs/TRUST_MODEL.md
+++ b/docs/TRUST_MODEL.md
@@ -111,10 +111,10 @@ custody*. There are operator-controlled assumptions that affect
   (already done via `ResolverRegistry`) and let arbitrage incentives
   attract honest resolvers.
 - **Soroban resolver registry binding.** The HTLC contract on Soroban
-  has a soft hook for the registry but does not yet enforce
-  `is_authorised` at create time. This is intentional for v2.0 — the
-  HTLC is correct without the check — and will be tightened in v2.1
-  once the registry is battle-tested.
+  calls the registry's `is_active` check during `create_order` when a
+  registry is configured. `claim_order` and `refund_order` remain
+  permissionless so the hashlock and timelock recovery paths keep
+  working even if registry administration is compromised.
 
 ## References
 

--- a/soroban/contracts/htlc/Cargo.toml
+++ b/soroban/contracts/htlc/Cargo.toml
@@ -16,4 +16,5 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
+oversync-resolver-registry = { path = "../resolver-registry" }
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/soroban/contracts/htlc/src/lib.rs
+++ b/soroban/contracts/htlc/src/lib.rs
@@ -21,7 +21,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error,
-    symbol_short, token, Address, Bytes, BytesN, Env, Symbol,
+    symbol_short, token, vec, Address, Bytes, BytesN, Env, IntoVal, Symbol,
 };
 
 #[cfg(test)]
@@ -239,19 +239,20 @@ impl HtlcContract {
         }
 
         // If a resolver registry is configured, require the sender to
-        // be either an authorised resolver or a regular user explicitly
-        // allowed by the registry. The registry contract owns this
-        // policy decision.
-        if let Some(_registry) = env
+        // be active in that registry before accepting a new order.
+        if let Some(registry) = env
             .storage()
             .instance()
             .get::<DataKey, Address>(&DataKey::ResolverRegistry)
         {
-            // Phase 3 wires this into the actual ResolverRegistry contract
-            // via cross-contract `is_authorised(sender)` call. The HTLC
-            // is correct without this check (funds are still locked by
-            // hashlock + timelock), so we keep it as a soft hook for
-            // now.
+            let active: bool = env.invoke_contract(
+                &registry,
+                &symbol_short!("is_active"),
+                vec![&env, sender.clone().into_val(&env)],
+            );
+            if !active {
+                panic_with_error!(&env, Error::ResolverNotAuthorised);
+            }
         }
 
         let now = env.ledger().timestamp();

--- a/soroban/contracts/htlc/src/test.rs
+++ b/soroban/contracts/htlc/src/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use crate::{Error, HtlcContract, HtlcContractClient, Order, OrderStatus};
+use oversync_resolver_registry::{ResolverRegistry, ResolverRegistryClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     token::{StellarAssetClient, TokenClient},
@@ -28,6 +29,19 @@ fn setup(env: &Env, min_safety_deposit: i128) -> (Address, HtlcContractClient<'_
     env.mock_all_auths();
     client.initialize(&admin, &min_safety_deposit);
     (admin, client)
+}
+
+fn deploy_registry<'a>(
+    env: &Env,
+    admin: &Address,
+    stake_asset: &Address,
+    min_stake: i128,
+    slash_beneficiary: &Address,
+) -> (Address, ResolverRegistryClient<'a>) {
+    let registry_id = env.register(ResolverRegistry, ());
+    let registry = ResolverRegistryClient::new(env, &registry_id);
+    registry.initialize(admin, stake_asset, &min_stake, slash_beneficiary);
+    (registry_id, registry)
 }
 
 fn advance_ledger(env: &Env, seconds: u64) {
@@ -344,4 +358,67 @@ fn initialise_twice_fails() {
     let again = Address::generate(&env);
     let res = htlc.try_initialize(&again, &0);
     assert_eq!(res.err().unwrap().unwrap(), Error::AlreadyInitialised.into());
+}
+
+#[test]
+fn active_resolver_can_create_order_when_registry_is_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let asset_admin = Address::generate(&env);
+    let (asset, sac, _token) = deploy_token(&env, &asset_admin);
+    let (admin, htlc) = setup(&env, 0);
+
+    let sender = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    sac.mint(&sender, &100_0000000);
+
+    let (registry_id, registry) = deploy_registry(&env, &admin, &asset, 10_0000000, &admin);
+    registry.register(&sender, &10_0000000);
+    htlc.set_resolver_registry(&registry_id);
+
+    let preimage = Bytes::from_array(&env, &[11u8; 32]);
+    let hashlock = sha256_32(&env, &preimage);
+    let order_id = htlc.create_order(
+        &sender,
+        &beneficiary,
+        &sender,
+        &asset,
+        &20_0000000i128,
+        &0i128,
+        &hashlock,
+        &600u64,
+    );
+
+    assert_eq!(order_id, 1);
+}
+
+#[test]
+fn inactive_resolver_cannot_create_order_when_registry_is_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let asset_admin = Address::generate(&env);
+    let (asset, sac, _token) = deploy_token(&env, &asset_admin);
+    let (admin, htlc) = setup(&env, 0);
+
+    let sender = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    sac.mint(&sender, &100_0000000);
+
+    let (registry_id, _registry) = deploy_registry(&env, &admin, &asset, 10_0000000, &admin);
+    htlc.set_resolver_registry(&registry_id);
+
+    let preimage = Bytes::from_array(&env, &[12u8; 32]);
+    let hashlock = sha256_32(&env, &preimage);
+    let res = htlc.try_create_order(
+        &sender,
+        &beneficiary,
+        &sender,
+        &asset,
+        &20_0000000i128,
+        &0i128,
+        &hashlock,
+        &600u64,
+    );
+
+    assert_eq!(res.err().unwrap().unwrap(), Error::ResolverNotAuthorised.into());
 }


### PR DESCRIPTION
## Summary
- enforce the configured Soroban resolver registry during `create_order`
- add active and inactive resolver coverage around the HTLC binding
- update trust model and architecture notes to reflect the enforced check

## Checks
- git diff --check

Closes #6