### PR TITLE
feat(e2e): add Sepolia/Stellar load-test harness scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,11 @@ yarn.lock
 .coverage/
 junit.xml
 
+# Load-test report artefacts (keep .gitkeep but not generated reports)
+e2e/load-test/reports/*.json
+e2e/load-test/reports/*.md
+# Fallback if LOAD_TEST_OUTPUT_DIR is set to an absolute path outside the tree
+
 # Miscellaneous
 .cache/
 .parcel-cache/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ setting `VITE_MAINNET_ENABLED=true` in the frontend env (see
 | Foundry fuzz + invariant suite for `HTLCEscrow.sol` | 🛠 | `contracts/test/foundry/` directory + CI gate | GitHub Actions |
 | Slither must-not-fail CI gate (currently advisory) | 🛠 | Slither failure breaks the build | GitHub Actions |
 | Differential test harness across EVM ↔ Soroban (same hashlock and preimage round-trip) | 🗓 | `e2e/cross-chain.test.ts` | Local + CI |
-| Sepolia load test (1k concurrent orders, 2-week soak) | 🗓 | Public Sepolia dashboard + report | Dashboard URL |
+| Sepolia load test (1k concurrent orders, 2-week soak) | 🗓 | Public Sepolia dashboard + report (harness: [`e2e/load-test/`](e2e/load-test/harness.ts) · dry-run: `pnpm load-test` · live: `pnpm load-test:live`) | Dashboard URL |
 | Soroban resolver-registry binding enforcement in HTLC (currently soft) | 🗓 | Contract upgrade + 2 new tests | Soroban testnet |
 | Coordinator Postgres migration path | 🗓 | `coordinator/migrations/` + integration test | CI |
 | Coordinator observability stack (Prometheus + Grafana) | 🗓 | `coordinator/ops/` Docker compose | Repo |

--- a/e2e/load-test/config.ts
+++ b/e2e/load-test/config.ts
@@ -1,0 +1,116 @@
+/**
+ * Load-test configuration.
+ *
+ * All knobs are driven by environment variables so the harness is
+ * reproducible in CI. Safe dry-run defaults mean contributors can run
+ * locally without any live RPC or private keys.
+ *
+ * Env vars:
+ *   LOAD_TEST_LIVE=true          — opt in to live Sepolia/Stellar testnet
+ *   LOAD_TEST_SEED               — PRNG seed (default: "oversync-soak-2026")
+ *   LOAD_TEST_ORDERS             — order count (default: 10 dry-run / 100 live)
+ *   LOAD_TEST_CONCURRENCY        — parallel workers (default: 10 dry-run / 5 live)
+ *   LOAD_TEST_RATE_PER_SEC       — orders/sec rate cap (default: 100 dry-run / 3 live)
+ *   LOAD_TEST_TIMELOCK_SEC       — HTLC timelock in seconds (default: 600)
+ *   LOAD_TEST_OUTPUT_DIR         — where reports land (default: load-test/reports)
+ *   LOAD_TEST_ALLOW_LARGE=true   — bypass the 100-order live-mode safeguard
+ *
+ *   Live mode also requires at least one of:
+ *     SEPOLIA_RPC_URL or INFURA_API_KEY
+ *     RESOLVER_ETH_PRIVATE_KEY
+ */
+
+export interface LoadTestConfig {
+  dryRun: boolean;
+  seed: string;
+  orders: number;
+  concurrency: number;
+  rateLimitPerSec: number;
+  timelockSeconds: number;
+  outputDir: string;
+  sepoliaRpcUrl: string | null;
+  sorobanRpcUrl: string | null;
+}
+
+function parsePositiveInt(name: string, defaultVal: number, max: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultVal;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`${name} must be a positive integer, got: ${raw}`);
+  }
+  if (n > max) {
+    throw new Error(
+      `${name}=${n} exceeds the safety cap of ${max}. ` +
+        "Set LOAD_TEST_ALLOW_LARGE=true to override."
+    );
+  }
+  return n;
+}
+
+export function loadConfig(): LoadTestConfig {
+  const dryRun = process.env.LOAD_TEST_LIVE !== "true";
+  const allowLarge = process.env.LOAD_TEST_ALLOW_LARGE === "true";
+
+  const orderCap = allowLarge ? 100_000 : dryRun ? 10_000 : 100;
+  const defaultOrders = dryRun ? 10 : 100;
+
+  const orders = parsePositiveInt("LOAD_TEST_ORDERS", defaultOrders, orderCap);
+  const concurrency = parsePositiveInt(
+    "LOAD_TEST_CONCURRENCY",
+    dryRun ? 10 : 5,
+    dryRun ? 200 : 50
+  );
+  const rateLimitPerSec = parsePositiveInt(
+    "LOAD_TEST_RATE_PER_SEC",
+    dryRun ? 100 : 3,
+    dryRun ? 10_000 : 50
+  );
+  const timelockSeconds = parsePositiveInt("LOAD_TEST_TIMELOCK_SEC", 600, 86_400);
+
+  if (!dryRun) {
+    const hasRpc = !!(process.env.SEPOLIA_RPC_URL || process.env.INFURA_API_KEY);
+    if (!hasRpc) {
+      throw new Error(
+        "Live mode requires SEPOLIA_RPC_URL or INFURA_API_KEY.\n" +
+          "Unset LOAD_TEST_LIVE to use dry-run mode instead."
+      );
+    }
+    if (!process.env.RESOLVER_ETH_PRIVATE_KEY) {
+      throw new Error(
+        "Live mode requires RESOLVER_ETH_PRIVATE_KEY.\n" +
+          "Unset LOAD_TEST_LIVE to use dry-run mode instead."
+      );
+    }
+    if (rateLimitPerSec > 5) {
+      process.stderr.write(
+        `[WARN] LOAD_TEST_RATE_PER_SEC=${rateLimitPerSec} in live mode — ` +
+          "Sepolia/Stellar testnet RPC providers may rate-limit above 3/sec.\n"
+      );
+    }
+    if (!allowLarge && orders > 100) {
+      throw new Error(
+        `Live mode with ${orders} orders requires LOAD_TEST_ALLOW_LARGE=true (testnet cost safeguard).`
+      );
+    }
+  }
+
+  const sepoliaRpcUrl =
+    process.env.SEPOLIA_RPC_URL ??
+    (process.env.INFURA_API_KEY
+      ? `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY}`
+      : null);
+
+  return {
+    dryRun,
+    seed: process.env.LOAD_TEST_SEED ?? "oversync-soak-2026",
+    orders,
+    concurrency,
+    rateLimitPerSec,
+    timelockSeconds,
+    outputDir: process.env.LOAD_TEST_OUTPUT_DIR ?? "reports",
+    sepoliaRpcUrl,
+    sorobanRpcUrl:
+      process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org",
+  };
+}

--- a/e2e/load-test/harness.ts
+++ b/e2e/load-test/harness.ts
@@ -1,0 +1,160 @@
+/**
+ * OverSync Sepolia/Stellar load-test harness.
+ *
+ * Dry-run (default — no keys or live RPC needed):
+ *   pnpm --filter @oversync/e2e load-test
+ *
+ * Custom order count / seed:
+ *   LOAD_TEST_ORDERS=50 LOAD_TEST_SEED=my-run pnpm --filter @oversync/e2e load-test
+ *
+ * Live testnet mode (requires SEPOLIA_RPC_URL + RESOLVER_ETH_PRIVATE_KEY):
+ *   LOAD_TEST_LIVE=true LOAD_TEST_ORDERS=20 pnpm --filter @oversync/e2e load-test
+ *
+ * Full 1k-order soak (requires LOAD_TEST_ALLOW_LARGE=true in live mode):
+ *   LOAD_TEST_LIVE=true LOAD_TEST_ORDERS=1000 LOAD_TEST_ALLOW_LARGE=true \
+ *     LOAD_TEST_RATE_PER_SEC=3 pnpm --filter @oversync/e2e load-test
+ *
+ * See e2e/load-test/config.ts for the full list of env vars.
+ */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfig } from "./config.js";
+import { generateOrders } from "./orders.js";
+import { runOrders } from "./runner.js";
+import { buildReport, writeReports } from "./report.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function bar(filled: number, total: number, width = 30): string {
+  const pct = total > 0 ? filled / total : 0;
+  const done = Math.round(pct * width);
+  return `[${"#".repeat(done)}${".".repeat(width - done)}] ${(pct * 100).toFixed(0).padStart(3)} %`;
+}
+
+async function main(): Promise<void> {
+  // -------------------------------------------------------------------------
+  // 1. Load + validate config
+  // -------------------------------------------------------------------------
+  let config;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    process.stderr.write(
+      `\n[ERROR] Configuration failure:\n  ${err instanceof Error ? err.message : err}\n\n`
+    );
+    process.stderr.write(
+      "Run without LOAD_TEST_LIVE to use dry-run mode (no keys required).\n\n"
+    );
+    process.exit(1);
+  }
+
+  const mode = config.dryRun ? "DRY-RUN (simulated)" : "LIVE — Sepolia + Stellar testnet";
+
+  process.stdout.write(`\n${"═".repeat(56)}\n`);
+  process.stdout.write(`  OverSync Load-Test Harness\n`);
+  process.stdout.write(`${"═".repeat(56)}\n`);
+  process.stdout.write(`  Mode         : ${mode}\n`);
+  process.stdout.write(`  Seed         : ${config.seed}\n`);
+  process.stdout.write(`  Orders       : ${config.orders}\n`);
+  process.stdout.write(`  Concurrency  : ${config.concurrency} workers\n`);
+  process.stdout.write(`  Rate limit   : ${config.rateLimitPerSec} orders / sec\n`);
+  process.stdout.write(`  Timelock     : ${config.timelockSeconds} s\n`);
+  if (!config.dryRun) {
+    process.stdout.write(`  Sepolia RPC  : ${config.sepoliaRpcUrl}\n`);
+    process.stdout.write(`  Soroban RPC  : ${config.sorobanRpcUrl}\n`);
+  }
+  process.stdout.write(`${"─".repeat(56)}\n\n`);
+
+  // -------------------------------------------------------------------------
+  // 2. Generate deterministic orders
+  // -------------------------------------------------------------------------
+  process.stdout.write(`Generating ${config.orders} deterministic orders...\n`);
+  const orders = generateOrders(config.seed, config.orders, config.timelockSeconds);
+
+  const ethToXlm = orders.filter((o) => o.direction === "ETH_TO_XLM").length;
+  const xlmToEth = orders.filter((o) => o.direction === "XLM_TO_ETH").length;
+  const plannedFills = orders.filter((o) => o.resolverAction === "fill").length;
+  const plannedTimeouts = orders.filter((o) => o.resolverAction === "timeout").length;
+
+  process.stdout.write(
+    `  Direction mix : ${ethToXlm} ETH→XLM  /  ${xlmToEth} XLM→ETH\n`
+  );
+  process.stdout.write(
+    `  Resolver plan : ${plannedFills} fills  /  ${plannedTimeouts} timeouts\n`
+  );
+  process.stdout.write(
+    `  Est. RPC calls: ${plannedFills * 4 + plannedTimeouts * 3}\n\n`
+  );
+
+  // -------------------------------------------------------------------------
+  // 3. Run
+  // -------------------------------------------------------------------------
+  process.stdout.write(`Running orders...\n`);
+  const startMs = Date.now();
+  let lastPrint = 0;
+
+  const results = await runOrders(orders, config, (_result, completed, total) => {
+    const now = Date.now();
+    if (now - lastPrint >= 250 || completed === total) {
+      process.stdout.write(`\r  ${bar(completed, total)}  ${completed}/${total}`);
+      lastPrint = now;
+    }
+  });
+
+  const durationMs = Date.now() - startMs;
+  process.stdout.write(`\n\n`);
+
+  // -------------------------------------------------------------------------
+  // 4. Summarise to stdout
+  // -------------------------------------------------------------------------
+  const filled = results.filter((r) => r.status === "filled").length;
+  const timedOut = results.filter((r) => r.status === "timed-out").length;
+  const failed = results.filter((r) => r.status === "failed").length;
+  const passRate =
+    results.length > 0
+      ? (((filled + timedOut) / results.length) * 100).toFixed(1)
+      : "0.0";
+
+  process.stdout.write(`${"─".repeat(56)}\n`);
+  process.stdout.write(`  Filled        : ${filled}\n`);
+  process.stdout.write(`  Timed-out     : ${timedOut}\n`);
+  process.stdout.write(`  Failed        : ${failed}\n`);
+  process.stdout.write(`  Pass rate     : ${passRate} %\n`);
+  process.stdout.write(`  Duration      : ${(durationMs / 1000).toFixed(2)} s\n`);
+  process.stdout.write(`${"─".repeat(56)}\n\n`);
+
+  if (failed > 0) {
+    const sample = results
+      .filter((r) => r.status === "failed")
+      .slice(0, 3);
+    process.stderr.write(`[WARN] ${failed} order(s) failed. First failures:\n`);
+    for (const f of sample) {
+      process.stderr.write(`  #${f.index} ${f.orderId} — ${f.errorMessage}\n`);
+    }
+    if (failed > 3) {
+      process.stderr.write(`  …and ${failed - 3} more (see JSON report).\n`);
+    }
+    process.stderr.write(`\n`);
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. Write reports
+  // -------------------------------------------------------------------------
+  const report = buildReport(config, orders, results, durationMs);
+  const outputDir = resolve(here, config.outputDir);
+  const { jsonPath, mdPath } = writeReports(report, outputDir);
+
+  process.stdout.write(`Reports written:\n`);
+  process.stdout.write(`  JSON : ${jsonPath}\n`);
+  process.stdout.write(`  MD   : ${mdPath}\n\n`);
+  process.stdout.write(
+    `Reproduce: LOAD_TEST_SEED=${config.seed} pnpm --filter @oversync/e2e load-test\n\n`
+  );
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  process.stderr.write(`\n[FATAL] ${err instanceof Error ? err.stack : err}\n`);
+  process.exit(1);
+});

--- a/e2e/load-test/orders.ts
+++ b/e2e/load-test/orders.ts
@@ -1,0 +1,90 @@
+/**
+ * Deterministic order generator.
+ *
+ * All orders are derived from (seed, index) using sha256 so the same seed
+ * always produces the same sequence. No RNG state, no side effects.
+ */
+import { createHash } from "node:crypto";
+
+export type Hex = `0x${string}`;
+export type Direction = "ETH_TO_XLM" | "XLM_TO_ETH";
+export type ResolverAction = "fill" | "timeout";
+
+export interface PlannedOrder {
+  index: number;
+  /** Short deterministic hex tag used in logs and reports (not an on-chain ID). */
+  orderId: string;
+  preimage: Hex;
+  /** sha256(preimage) — the hashlock used by both HTLC implementations. */
+  hashlock: Hex;
+  direction: Direction;
+  /** Notional ETH amount in wei (informational only in dry-run). */
+  amountWei: bigint;
+  /**
+   * Planned resolver action:
+   *   fill    — resolver claims before timelock (≈80 % of orders)
+   *   timeout — resolver withholds; both sides refund after timelock (≈20 %)
+   */
+  resolverAction: ResolverAction;
+  timelockSeconds: number;
+}
+
+// Derives a deterministic 32-byte buffer for a given (seed, role, index) triple.
+function deterministicBytes(seed: string, role: string, index: number): Buffer {
+  return createHash("sha256")
+    .update(`${seed}:${role}:${index}`)
+    .digest();
+}
+
+// Returns the first byte (0–255) derived from a given slot — cheap coin flip.
+function slotByte(seed: string, role: string, index: number): number {
+  return deterministicBytes(seed, role, index)[0];
+}
+
+export function generateOrders(
+  seed: string,
+  count: number,
+  timelockSeconds: number
+): PlannedOrder[] {
+  const orders: PlannedOrder[] = [];
+
+  for (let i = 0; i < count; i++) {
+    // Preimage: sha256(seed:preimage:i)
+    const preimageBytes = deterministicBytes(seed, "preimage", i);
+    const preimage: Hex = `0x${preimageBytes.toString("hex")}`;
+
+    // Hashlock: sha256(preimage) — mirrors what both HTLC contracts enforce.
+    const hashlockBytes = createHash("sha256").update(preimageBytes).digest();
+    const hashlock: Hex = `0x${hashlockBytes.toString("hex")}`;
+
+    // Short order tag for human-readable output (first 8 bytes of the hashlock).
+    const orderId = `0x${hashlockBytes.toString("hex").slice(0, 16)}`;
+
+    // Direction: 50/50 split.
+    const direction: Direction =
+      slotByte(seed, "direction", i) < 128 ? "ETH_TO_XLM" : "XLM_TO_ETH";
+
+    // Resolver action: ~80 % fill, ~20 % timeout.
+    const resolverAction: ResolverAction =
+      slotByte(seed, "action", i) < 205 ? "fill" : "timeout";
+
+    // Notional amount: 0.001–0.09 ETH expressed in wei (informational).
+    const amountByte = slotByte(seed, "amount", i);
+    const amountWei =
+      BigInt(1_000_000_000_000_000) +
+      BigInt(amountByte) * BigInt(345_098_039_000_000);
+
+    orders.push({
+      index: i,
+      orderId,
+      preimage,
+      hashlock,
+      direction,
+      amountWei,
+      resolverAction,
+      timelockSeconds,
+    });
+  }
+
+  return orders;
+}

--- a/e2e/load-test/report.ts
+++ b/e2e/load-test/report.ts
@@ -1,0 +1,230 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { PlannedOrder } from "./orders.js";
+import type { LoadTestConfig } from "./config.js";
+import type { OrderResult } from "./runner.js";
+
+// ---------------------------------------------------------------------------
+// Report shape
+// ---------------------------------------------------------------------------
+
+export interface SoakReport {
+  meta: {
+    timestamp: string;
+    seed: string;
+    dryRun: boolean;
+    durationMs: number;
+  };
+  config: {
+    orders: number;
+    concurrency: number;
+    rateLimitPerSec: number;
+    timelockSeconds: number;
+  };
+  summary: {
+    totalOrders: number;
+    filled: number;
+    timedOut: number;
+    failed: number;
+    ethToXlm: number;
+    xlmToEth: number;
+    /**
+     * fill: 4 RPC calls (fund + claim on each chain)
+     * timeout: 3 RPC calls (fund on each chain + 1 timelock-check each = 4,
+     *          but we credit 3 to be conservative since one side self-expires)
+     */
+    estimatedRpcCalls: number;
+    p50DurationMs: number;
+    p95DurationMs: number;
+    maxDurationMs: number;
+  };
+  failures: Array<{ index: number; orderId: string; error: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+export function buildReport(
+  config: LoadTestConfig,
+  orders: PlannedOrder[],
+  results: OrderResult[],
+  durationMs: number
+): SoakReport {
+  const filled = results.filter((r) => r.status === "filled").length;
+  const timedOut = results.filter((r) => r.status === "timed-out").length;
+  const failed = results.filter((r) => r.status === "failed").length;
+
+  const ethToXlm = orders.filter((o) => o.direction === "ETH_TO_XLM").length;
+  const xlmToEth = orders.filter((o) => o.direction === "XLM_TO_ETH").length;
+
+  const estimatedRpcCalls = filled * 4 + timedOut * 3;
+
+  const durations = results.map((r) => r.durationMs).sort((a, b) => a - b);
+
+  return {
+    meta: {
+      timestamp: new Date().toISOString(),
+      seed: config.seed,
+      dryRun: config.dryRun,
+      durationMs,
+    },
+    config: {
+      orders: config.orders,
+      concurrency: config.concurrency,
+      rateLimitPerSec: config.rateLimitPerSec,
+      timelockSeconds: config.timelockSeconds,
+    },
+    summary: {
+      totalOrders: results.length,
+      filled,
+      timedOut,
+      failed,
+      ethToXlm,
+      xlmToEth,
+      estimatedRpcCalls,
+      p50DurationMs: percentile(durations, 50),
+      p95DurationMs: percentile(durations, 95),
+      maxDurationMs: durations[durations.length - 1] ?? 0,
+    },
+    failures: results
+      .filter((r) => r.status === "failed")
+      .map((r) => ({
+        index: r.index,
+        orderId: r.orderId,
+        error: r.errorMessage ?? "unknown",
+      })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown renderer
+// ---------------------------------------------------------------------------
+
+export function toMarkdown(report: SoakReport): string {
+  const { meta, config, summary } = report;
+  const mode = meta.dryRun
+    ? "**DRY-RUN** (no live RPC)"
+    : "**LIVE** — Sepolia + Stellar testnet";
+
+  const passRate =
+    summary.totalOrders > 0
+      ? (
+          ((summary.filled + summary.timedOut) / summary.totalOrders) *
+          100
+        ).toFixed(1)
+      : "0.0";
+
+  const lines: string[] = [
+    `# OverSync Soak-Test Report`,
+    ``,
+    `| | |`,
+    `|---|---|`,
+    `| **Mode** | ${mode} |`,
+    `| **Timestamp** | \`${meta.timestamp}\` |`,
+    `| **Seed** | \`${meta.seed}\` |`,
+    `| **Total duration** | ${(meta.durationMs / 1000).toFixed(2)} s |`,
+    ``,
+    `## Configuration`,
+    ``,
+    `| Parameter | Value |`,
+    `|---|---|`,
+    `| Orders planned | ${config.orders} |`,
+    `| Concurrency | ${config.concurrency} workers |`,
+    `| Rate limit | ${config.rateLimitPerSec} orders / sec |`,
+    `| Timelock | ${config.timelockSeconds} s |`,
+    ``,
+    `## Results`,
+    ``,
+    `| Metric | Count |`,
+    `|---|---|`,
+    `| Total orders | ${summary.totalOrders} |`,
+    `| Filled | ${summary.filled} |`,
+    `| Timed-out (refunded) | ${summary.timedOut} |`,
+    `| Failed | ${summary.failed} |`,
+    `| Pass rate | ${passRate} % |`,
+    ``,
+    `## Direction mix`,
+    ``,
+    `| Direction | Count |`,
+    `|---|---|`,
+    `| ETH → XLM | ${summary.ethToXlm} |`,
+    `| XLM → ETH | ${summary.xlmToEth} |`,
+    ``,
+    `## Estimated RPC load`,
+    ``,
+    `| Metric | Value |`,
+    `|---|---|`,
+    `| Total estimated calls | ${summary.estimatedRpcCalls} |`,
+    `| Calls per order (avg) | ${summary.totalOrders > 0 ? (summary.estimatedRpcCalls / summary.totalOrders).toFixed(1) : 0} |`,
+    ``,
+    `> **Note:** fill = 4 calls (fund + claim on each chain);`,
+    `> timeout = 3 calls (fund + refund on the initiating chain + 1 timelock poll).`,
+    ``,
+    `## Latency (per-order processing time)`,
+    ``,
+    `| Percentile | Duration |`,
+    `|---|---|`,
+    `| p50 | ${summary.p50DurationMs} ms |`,
+    `| p95 | ${summary.p95DurationMs} ms |`,
+    `| max | ${summary.maxDurationMs} ms |`,
+  ];
+
+  if (summary.failed > 0) {
+    lines.push(``, `## Failures`, ``);
+    lines.push(`| Index | Order ID | Error |`);
+    lines.push(`|---|---|---|`);
+    for (const f of report.failures.slice(0, 50)) {
+      lines.push(`| ${f.index} | \`${f.orderId}\` | ${f.error} |`);
+    }
+    if (report.failures.length > 50) {
+      lines.push(
+        ``,
+        `_…and ${report.failures.length - 50} more. See the JSON report for the full list._`
+      );
+    }
+  }
+
+  lines.push(
+    ``,
+    `---`,
+    ``,
+    `*Generated by the OverSync load-test harness.*`,
+    `*Reproduce: \`LOAD_TEST_SEED=${meta.seed} pnpm --filter @oversync/e2e load-test\`*`
+  );
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Write to disk
+// ---------------------------------------------------------------------------
+
+export function writeReports(
+  report: SoakReport,
+  outputDir: string
+): { jsonPath: string; mdPath: string } {
+  mkdirSync(outputDir, { recursive: true });
+
+  // e.g. 2026-06-24T14-30-00_oversync-soak-2026
+  const ts = report.meta.timestamp
+    .replace(/\.\d+Z$/, "Z")
+    .replace(/[:.]/g, "-")
+    .replace("T", "_");
+  const seedSlug = report.meta.seed.replace(/[^a-z0-9]/gi, "-").toLowerCase();
+  const base = `${ts}_${seedSlug}`;
+
+  const jsonPath = join(outputDir, `${base}.json`);
+  const mdPath = join(outputDir, `${base}.md`);
+
+  writeFileSync(jsonPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+  writeFileSync(mdPath, toMarkdown(report) + "\n", "utf8");
+
+  return { jsonPath, mdPath };
+}

--- a/e2e/load-test/runner.ts
+++ b/e2e/load-test/runner.ts
@@ -1,0 +1,180 @@
+/**
+ * Rate-limited concurrency runner.
+ *
+ * In dry-run mode every order is exercised through the in-process
+ * EvmHtlcSim / SorobanHtlcSim so the full claim/refund state machine is
+ * exercised without any live RPC calls.
+ *
+ * In live mode the stub throws a clear "not yet implemented" error so that
+ * someone wiring up real Sepolia/Soroban clients cannot accidentally submit
+ * a half-finished implementation to testnet.
+ */
+import type { PlannedOrder } from "./orders.js";
+import type { LoadTestConfig } from "./config.js";
+import { EvmHtlcSim, SorobanHtlcSim } from "../sim.js";
+
+export interface OrderResult {
+  index: number;
+  orderId: string;
+  direction: PlannedOrder["direction"];
+  resolverAction: PlannedOrder["resolverAction"];
+  status: "filled" | "timed-out" | "failed";
+  errorMessage?: string;
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run execution
+// ---------------------------------------------------------------------------
+
+function executeDryRun(order: PlannedOrder): OrderResult {
+  const start = Date.now();
+  try {
+    const evm = new EvmHtlcSim();
+    const soroban = new SorobanHtlcSim();
+
+    const evmId = evm.createOrder({
+      hashlock: order.hashlock,
+      timelockSeconds: order.timelockSeconds,
+    });
+    const sorobanId = soroban.createOrder({
+      hashlock: order.hashlock,
+      timelockSeconds: order.timelockSeconds,
+    });
+
+    if (order.resolverAction === "fill") {
+      // Direction determines which chain the resolver claims first, but both
+      // must eventually be claimed with the same preimage.
+      if (order.direction === "ETH_TO_XLM") {
+        evm.claimOrder(evmId, order.preimage);
+        soroban.claimOrder(sorobanId, order.preimage);
+      } else {
+        soroban.claimOrder(sorobanId, order.preimage);
+        evm.claimOrder(evmId, order.preimage);
+      }
+      return {
+        index: order.index,
+        orderId: order.orderId,
+        direction: order.direction,
+        resolverAction: order.resolverAction,
+        status: "filled",
+        durationMs: Date.now() - start,
+      };
+    }
+
+    // timeout path: advance both clocks past the timelock, then refund.
+    evm.advanceTime(order.timelockSeconds + 1);
+    soroban.advanceTime(order.timelockSeconds + 1);
+    evm.refundOrder(evmId);
+    soroban.refundOrder(sorobanId);
+
+    return {
+      index: order.index,
+      orderId: order.orderId,
+      direction: order.direction,
+      resolverAction: order.resolverAction,
+      status: "timed-out",
+      durationMs: Date.now() - start,
+    };
+  } catch (err) {
+    return {
+      index: order.index,
+      orderId: order.orderId,
+      direction: order.direction,
+      resolverAction: order.resolverAction,
+      status: "failed",
+      errorMessage: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - start,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Live execution stub
+// ---------------------------------------------------------------------------
+
+function executeLive(order: PlannedOrder): OrderResult {
+  // This stub exists so that the harness config / rate-limiting / report
+  // machinery can be validated before real RPC calls are wired in.
+  // Replace this body with viem + @stellar/stellar-sdk calls before running
+  // the 1k-order soak.
+  return {
+    index: order.index,
+    orderId: order.orderId,
+    direction: order.direction,
+    resolverAction: order.resolverAction,
+    status: "failed",
+    errorMessage:
+      "Live RPC execution is not yet implemented. " +
+      "Wire up Sepolia/Soroban clients in runner.ts:executeLive() before scheduling the soak.",
+    durationMs: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Token-bucket rate limiter
+// ---------------------------------------------------------------------------
+
+class RateLimiter {
+  private tokens: number;
+  private lastRefill: number;
+
+  constructor(private readonly perSec: number) {
+    this.tokens = perSec;
+    this.lastRefill = Date.now();
+  }
+
+  async acquire(): Promise<void> {
+    for (;;) {
+      const now = Date.now();
+      const elapsed = (now - this.lastRefill) / 1000;
+      this.tokens = Math.min(this.perSec, this.tokens + elapsed * this.perSec);
+      this.lastRefill = now;
+
+      if (this.tokens >= 1) {
+        this.tokens -= 1;
+        return;
+      }
+
+      const waitMs = Math.ceil(((1 - this.tokens) / this.perSec) * 1000);
+      await new Promise<void>((r) => setTimeout(r, waitMs));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function runOrders(
+  orders: PlannedOrder[],
+  config: LoadTestConfig,
+  onProgress?: (result: OrderResult, completed: number, total: number) => void
+): Promise<OrderResult[]> {
+  const results: OrderResult[] = [];
+  const limiter = new RateLimiter(config.rateLimitPerSec);
+  let completed = 0;
+
+  // Share a mutable queue across all workers so they don't double-process.
+  const queue = [...orders];
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const order = queue.shift();
+      if (!order) return;
+
+      await limiter.acquire();
+
+      const result = config.dryRun ? executeDryRun(order) : executeLive(order);
+      results.push(result);
+      completed++;
+      onProgress?.(result, completed, orders.length);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: config.concurrency }, worker)
+  );
+
+  return results.sort((a, b) => a.index - b.index);
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "load-test": "tsx load-test/harness.ts"
   },
   "dependencies": {
     "@oversync/sdk": "workspace:*",
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.3.0",
     "vitest": "^2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "build:prod": "NODE_ENV=production pnpm -r build",
     "test": "pnpm -r test",
     "test:e2e": "pnpm --filter @oversync/e2e test",
+    "load-test": "pnpm --filter @oversync/e2e load-test",
+    "load-test:live": "LOAD_TEST_LIVE=true pnpm --filter @oversync/e2e load-test",
     "lint": "pnpm -r lint",
     "clean": "pnpm -r clean && rm -rf node_modules",
     "contracts:compile": "pnpm --filter contracts compile",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.7
+      tsx:
+        specifier: ^4.19.0
+        version: 4.20.3
       typescript:
         specifier: ^5.3.0
         version: 5.8.3
@@ -3854,7 +3857,7 @@ packages:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 5.4.19(@types/node@22.19.19)
+      vite: 5.4.19(@types/node@20.19.7)
     dev: true
 
   /@vitest/pretty-format@2.1.9:


### PR DESCRIPTION
Adds a repeatable soak-test harness under e2e/load-test/ as the basis for the Q3 1k-order Sepolia load test. Dry-run mode (default) exercises the full HTLC state machine through the existing simulators with no live RPC or private keys required. Live mode is gated behind explicit env vars and a 100-order safeguard to prevent accidental testnet spam.

- config.ts  : env-driven config; hard-refuses unsafe live defaults
- orders.ts  : deterministic generator (seed + sha256, 80/20 fill/timeout)
- runner.ts  : token-bucket rate limiter + configurable worker pool
- report.ts  : JSON + Markdown report (order count, direction mix, estimated RPC calls, latency percentiles, failure table)
- harness.ts : CLI entry point with progress bar; exits 1 on failures

Root shortcuts: pnpm load-test (dry) / pnpm load-test:live (live). ROADMAP.md soak milestone updated to reference the harness.

closes #32 