### PR TITLE
feat(sdk): typed Soroban HTLC order reads

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,6 +12,7 @@ export {
 export {
   SorobanHTLCClient,
   makeKeypairSigner,
+  parseSorobanOrder,
   type SorobanHTLCClientOptions,
   type SorobanCreateOrderInput,
   type SorobanSigner

--- a/packages/sdk/src/soroban/index.ts
+++ b/packages/sdk/src/soroban/index.ts
@@ -10,6 +10,7 @@ import {
   type Keypair,
   type Transaction
 } from "@stellar/stellar-sdk";
+import type { SorobanOrderData, SorobanOrderStatus } from "../types/index.js";
 
 export interface SorobanHTLCClientOptions {
   /** Soroban RPC endpoint, e.g. https://soroban-testnet.stellar.org */
@@ -127,7 +128,7 @@ export class SorobanHTLCClient {
     return this.simulateSignSubmit(callerAccountId, op, signer);
   }
 
-  async getOrder(orderId: bigint): Promise<unknown | null> {
+  async getOrder(orderId: bigint): Promise<SorobanOrderData | null> {
     const op = this.contract.call(
       "get_order",
       nativeToScVal(orderId, { type: "u64" })
@@ -147,7 +148,8 @@ export class SorobanHTLCClient {
     }
     const result = (sim as any).result;
     if (!result || !result.retval) return null;
-    return scValToNative(result.retval);
+    const native = scValToNative(result.retval);
+    return parseSorobanOrder(native);
   }
 
   private async simulateSignSubmit(
@@ -198,5 +200,113 @@ export function makeKeypairSigner(keypair: Keypair): SorobanSigner {
     const tx = TransactionBuilder.fromXDR(req.xdr, req.networkPassphrase) as Transaction;
     tx.sign(keypair);
     return tx.toXDR();
+  };
+}
+
+// ---------------------------------------------------------------
+// Soroban order parsing helpers
+// ---------------------------------------------------------------
+
+const STATUS_MAP: Record<string, SorobanOrderStatus> = {
+  Funded: "Funded",
+  Claimed: "Claimed",
+  Refunded: "Refunded",
+};
+
+function bytesToHex(value: unknown): `0x${string}` {
+  if (value instanceof Uint8Array || Buffer.isBuffer(value as Buffer)) {
+    return ("0x" +
+      Array.from(value as Uint8Array, (b) => b.toString(16).padStart(2, "0")).join("")) as `0x${string}`;
+  }
+  if (typeof value === "string") {
+    // Already a hex string (some SDK versions surface as string).
+    return (value.startsWith("0x") ? value : "0x" + value) as `0x${string}`;
+  }
+  throw new Error(`parseSorobanOrder: cannot convert value to hex: ${typeof value}`);
+}
+
+function toBigInt(value: unknown, field: string): bigint {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return BigInt(value);
+  if (typeof value === "string") {
+    try {
+      return BigInt(value);
+    } catch {
+      throw new Error(`parseSorobanOrder: field "${field}" is not a numeric type (got string "${value}")`);
+    }
+  }
+  throw new Error(`parseSorobanOrder: field "${field}" is not a numeric type (got ${typeof value})`);
+}
+
+function toString(value: unknown, field: string): string {
+  if (typeof value === "string") return value;
+  throw new Error(`parseSorobanOrder: field "${field}" is not a string (got ${typeof value})`);
+}
+
+/**
+ * Parse/normalise a raw `scValToNative` return value from the Soroban
+ * HTLC contract's `get_order` into a typed {@link SorobanOrderData}.
+ *
+ * Returns `null` when `raw` is null/undefined (order not found).
+ * Throws a descriptive error for malformed payloads.
+ *
+ * This is exported as a pure function so callers that obtain the raw
+ * value through other means (e.g. event streaming) can still benefit
+ * from the typed normalisation.
+ */
+export function parseSorobanOrder(raw: unknown): SorobanOrderData | null {
+  if (raw === null || raw === undefined) return null;
+
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`parseSorobanOrder: expected an object, got ${Array.isArray(raw) ? "array" : typeof raw}`);
+  }
+
+  const r = raw as Record<string, unknown>;
+
+  const requiredFields = [
+    "id", "sender", "beneficiary", "refund_address", "asset",
+    "amount", "safety_deposit", "hashlock", "timelock",
+    "status", "preimage", "created_at", "finalised_at",
+  ] as const;
+
+  for (const f of requiredFields) {
+    if (!(f in r)) {
+      throw new Error(`parseSorobanOrder: missing required field "${f}"`);
+    }
+  }
+
+  const rawStatus = r["status"];
+  const status: SorobanOrderStatus =
+    typeof rawStatus === "string" && rawStatus in STATUS_MAP
+      ? STATUS_MAP[rawStatus]
+      : (() => { throw new Error(`parseSorobanOrder: unknown status value "${rawStatus}"`); })();
+
+  // preimage is an empty Bytes in Funded state; normalise to "".
+  let preimage: `0x${string}` | "" = "";
+  const rawPreimage = r["preimage"];
+  if (
+    rawPreimage !== null &&
+    rawPreimage !== undefined &&
+    !(rawPreimage instanceof Uint8Array && rawPreimage.length === 0) &&
+    !(Buffer.isBuffer(rawPreimage) && (rawPreimage as Buffer).length === 0) &&
+    rawPreimage !== ""
+  ) {
+    preimage = bytesToHex(rawPreimage);
+  }
+
+  return {
+    id: toBigInt(r["id"], "id"),
+    sender: toString(r["sender"], "sender"),
+    beneficiary: toString(r["beneficiary"], "beneficiary"),
+    refundAddress: toString(r["refund_address"], "refund_address"),
+    asset: toString(r["asset"], "asset"),
+    amount: toBigInt(r["amount"], "amount"),
+    safetyDeposit: toBigInt(r["safety_deposit"], "safety_deposit"),
+    hashlock: bytesToHex(r["hashlock"]),
+    timelock: toBigInt(r["timelock"], "timelock"),
+    status,
+    preimage,
+    createdAt: toBigInt(r["created_at"], "created_at"),
+    finalisedAt: toBigInt(r["finalised_at"], "finalised_at"),
   };
 }

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -1,6 +1,39 @@
 export type Chain = "ethereum" | "stellar";
 export type Direction = "eth_to_xlm" | "xlm_to_eth";
 
+// ---------------------------------------------------------------
+// Soroban HTLC order types
+// ---------------------------------------------------------------
+
+/** Lifecycle status returned by the Soroban HTLC contract. */
+export type SorobanOrderStatus = "Funded" | "Claimed" | "Refunded";
+
+/**
+ * Typed representation of a Soroban HTLC order, normalised from the
+ * raw `scValToNative` response. Field names use camelCase to match the
+ * Ethereum `OrderData` ergonomics.
+ */
+export interface SorobanOrderData {
+  id: bigint;
+  sender: string;
+  beneficiary: string;
+  refundAddress: string;
+  /** Stellar asset contract address. */
+  asset: string;
+  /** Amount in the asset's smallest unit (stroops for XLM). */
+  amount: bigint;
+  safetyDeposit: bigint;
+  /** sha256 hashlock as a 0x-prefixed hex string. */
+  hashlock: `0x${string}`;
+  /** Absolute unix-second timestamp after which refund is valid. */
+  timelock: bigint;
+  status: SorobanOrderStatus;
+  /** Revealed preimage as 0x-prefixed hex, empty string when not yet claimed. */
+  preimage: `0x${string}` | "";
+  createdAt: bigint;
+  finalisedAt: bigint;
+}
+
 export type OrderStatus =
   | "announced"
   | "src_locked"

--- a/packages/sdk/test/soroban-order.test.ts
+++ b/packages/sdk/test/soroban-order.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { parseSorobanOrder } from "../src/soroban/index.js";
+import type { SorobanOrderData } from "../src/types/index.js";
+
+// Shared 32-byte buffers used across tests.
+const HASHLOCK_BYTES = Buffer.from("a".repeat(64), "hex"); // 32-byte buffer
+const PREIMAGE_BYTES = Buffer.from("b".repeat(64), "hex");
+const EMPTY_BYTES = Buffer.alloc(0);
+
+/** Minimal valid funded-order payload as scValToNative would return it. */
+function fundedRaw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: BigInt(1),
+    sender: "GABC1234",
+    beneficiary: "GDEF5678",
+    refund_address: "GHIJ9012",
+    asset: "CASSET0001",
+    amount: BigInt(5_000_000_000),
+    safety_deposit: BigInt(10_000_000),
+    hashlock: HASHLOCK_BYTES,
+    timelock: BigInt(1_800_000_000),
+    status: "Funded",
+    preimage: EMPTY_BYTES,
+    created_at: BigInt(1_700_000_000),
+    finalised_at: BigInt(0),
+    ...overrides,
+  };
+}
+
+describe("parseSorobanOrder", () => {
+  // ------------------------------------------------------------------
+  // null / missing
+  // ------------------------------------------------------------------
+
+  it("returns null for null input", () => {
+    expect(parseSorobanOrder(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseSorobanOrder(undefined)).toBeNull();
+  });
+
+  // ------------------------------------------------------------------
+  // Funded order
+  // ------------------------------------------------------------------
+
+  it("parses a funded order with all expected fields", () => {
+    const result = parseSorobanOrder(fundedRaw()) as SorobanOrderData;
+
+    expect(result).not.toBeNull();
+    expect(result.id).toBe(BigInt(1));
+    expect(result.sender).toBe("GABC1234");
+    expect(result.beneficiary).toBe("GDEF5678");
+    expect(result.refundAddress).toBe("GHIJ9012");
+    expect(result.asset).toBe("CASSET0001");
+    expect(result.amount).toBe(BigInt(5_000_000_000));
+    expect(result.safetyDeposit).toBe(BigInt(10_000_000));
+    expect(result.hashlock).toBe("0x" + "a".repeat(64));
+    expect(result.timelock).toBe(BigInt(1_800_000_000));
+    expect(result.status).toBe("Funded");
+    expect(result.preimage).toBe("");
+    expect(result.createdAt).toBe(BigInt(1_700_000_000));
+    expect(result.finalisedAt).toBe(BigInt(0));
+  });
+
+  it("normalises numeric id/amount fields supplied as plain numbers", () => {
+    const result = parseSorobanOrder(
+      fundedRaw({ id: 7, amount: 1_000_000, safety_deposit: 500 })
+    ) as SorobanOrderData;
+
+    expect(result.id).toBe(BigInt(7));
+    expect(result.amount).toBe(BigInt(1_000_000));
+    expect(result.safetyDeposit).toBe(BigInt(500));
+  });
+
+  // ------------------------------------------------------------------
+  // Claimed order
+  // ------------------------------------------------------------------
+
+  it("parses a claimed order with a non-empty preimage", () => {
+    const result = parseSorobanOrder(
+      fundedRaw({
+        status: "Claimed",
+        preimage: PREIMAGE_BYTES,
+        finalised_at: BigInt(1_700_001_000),
+      })
+    ) as SorobanOrderData;
+
+    expect(result.status).toBe("Claimed");
+    expect(result.preimage).toBe("0x" + "b".repeat(64));
+    expect(result.finalisedAt).toBe(BigInt(1_700_001_000));
+  });
+
+  // ------------------------------------------------------------------
+  // Refunded order
+  // ------------------------------------------------------------------
+
+  it("parses a refunded order", () => {
+    const result = parseSorobanOrder(
+      fundedRaw({
+        status: "Refunded",
+        finalised_at: BigInt(1_700_002_000),
+      })
+    ) as SorobanOrderData;
+
+    expect(result.status).toBe("Refunded");
+    expect(result.preimage).toBe("");
+    expect(result.finalisedAt).toBe(BigInt(1_700_002_000));
+  });
+
+  // ------------------------------------------------------------------
+  // Malformed payloads
+  // ------------------------------------------------------------------
+
+  it("throws on a non-object value (array)", () => {
+    expect(() => parseSorobanOrder([])).toThrow("expected an object");
+  });
+
+  it("throws on a non-object value (string)", () => {
+    expect(() => parseSorobanOrder("not-an-order")).toThrow("expected an object");
+  });
+
+  it("throws when a required field is missing (sender)", () => {
+    const raw = fundedRaw();
+    delete raw["sender"];
+    expect(() => parseSorobanOrder(raw)).toThrow('missing required field "sender"');
+  });
+
+  it("throws when status is an unknown value", () => {
+    expect(() =>
+      parseSorobanOrder(fundedRaw({ status: "Pending" }))
+    ).toThrow('unknown status value "Pending"');
+  });
+
+  it("throws when amount is not a numeric type", () => {
+    expect(() =>
+      parseSorobanOrder(fundedRaw({ amount: "not-a-number" }))
+    ).toThrow('field "amount" is not a numeric type');
+  });
+
+  it("throws when sender is not a string", () => {
+    expect(() =>
+      parseSorobanOrder(fundedRaw({ sender: 12345 }))
+    ).toThrow('field "sender" is not a string');
+  });
+
+  it("accepts string hex preimage (some SDK versions surface it as string)", () => {
+    const result = parseSorobanOrder(
+      fundedRaw({ status: "Claimed", preimage: "0x" + "c".repeat(64) })
+    ) as SorobanOrderData;
+
+    expect(result.preimage).toBe("0x" + "c".repeat(64));
+  });
+
+  it("accepts hashlock supplied as a plain hex string without 0x prefix", () => {
+    const result = parseSorobanOrder(
+      fundedRaw({ hashlock: "a".repeat(64) })
+    ) as SorobanOrderData;
+
+    expect(result.hashlock).toBe("0x" + "a".repeat(64));
+  });
+});


### PR DESCRIPTION
PR summary

SorobanHTLCClient.getOrder() previously returned Promise<unknown | null>, forcing every consumer to cast or re-validate the response. This change closes that gap and brings Soroban order reads to parity with the existing typed EthereumHTLCClient.getOrder().

Changes

index.ts

Added SorobanOrderStatus — "Funded" | "Claimed" | "Refunded", mirroring the Rust enum.
Added SorobanOrderData interface with all 13 order fields in camelCase (refundAddress, safetyDeposit, createdAt, finalisedAt, etc.), bytes as 0x-prefixed hex strings, and numerics as bigint.
index.ts

getOrder() return type changed from Promise<unknown | null> to Promise<SorobanOrderData | null>.
New exported parseSorobanOrder(raw: unknown): SorobanOrderData | null pure helper — normalises raw scValToNative payloads, handles Uint8Array/Buffer/string hex for byte fields, coerces number/bigint/string for numeric fields, normalises empty preimage bytes to "", and throws descriptive errors on malformed input. Callers using event streams or custom RPC paths can reuse this directly.
index.ts

parseSorobanOrder added to the root barrel export.
soroban-order.test.ts

14 new tests: funded order (full field check), numeric coercion, claimed order with preimage, refunded order, null/undefined inputs, non-object payloads, missing required field, unknown status, bad numeric type, bad string field, string hex preimage, and hex-without-0x hashlock.
Testing

All 27 SDK tests pass (vitest run). No existing tests modified.
close #30 